### PR TITLE
chore: tighten renovate pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,47 +1,43 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "javax.portlet:portlet-api"
-      ],
+      "matchPackageNames": ["javax.portlet:portlet-api"],
       "allowedVersions": "< 3.0",
       "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
     },
     {
-      "matchPackageNames": [
-        "org.springframework:spring-framework-bom",
-        "org.springframework:spring-aop",
-        "org.springframework:spring-beans",
-        "org.springframework:spring-context",
-        "org.springframework:spring-context-support",
-        "org.springframework:spring-core",
-        "org.springframework:spring-jdbc",
-        "org.springframework:spring-orm",
-        "org.springframework:spring-test",
-        "org.springframework:spring-tx",
-        "org.springframework:spring-web",
-        "org.springframework:spring-webmvc",
-        "org.springframework:spring-webmvc-portlet",
-        "org.springframework.data:spring-data-jpa"
-      ],
+      "matchPackagePrefixes": ["org.springframework:", "org.springframework.data:"],
       "allowedVersions": "< 4.0",
-      "description": "This portlet is pinned to Spring Framework 3.2.x. Next-major bumps require a coordinated migration."
+      "description": "This portlet is pinned to Spring Framework 3.2.x. Spring 4+ requires a coordinated migration."
+    },
+    {
+      "matchPackagePrefixes": ["org.hibernate:", "org.hibernate.orm:"],
+      "allowedVersions": "< 4.0",
+      "description": "Pinned to Hibernate 3.2.x. Later majors require Spring 5+, Jakarta EE, or Java 17+."
     },
     {
       "matchPackageNames": [
-        "org.hibernate:hibernate-core",
-        "org.hibernate:hibernate-ehcache",
-        "org.hibernate:hibernate-entitymanager",
-        "org.hibernate:hibernate-jpamodelgen",
-        "org.hibernate:hibernate-tools",
-        "org.hibernate:hibernate-validator",
-        "org.hibernate.orm:hibernate-core"
+        "com.sun.xml.bind:jaxb-impl",
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
       ],
-      "allowedVersions": "< 4.0",
-      "description": "Pinned to Hibernate 3.2.x. Later majors require Jakarta EE or Java 17+, neither of which match this portlet."
+      "allowedVersions": "< 3.0",
+      "description": "The 2.x releases preserve the javax.xml.bind.* package namespace. 3+ moves to jakarta.xml.bind as part of Jakarta EE 9+, which this portlet is not migrating to yet."
+    },
+    {
+      "matchPackageNames": ["org.codehaus.plexus:plexus-archiver"],
+      "allowedVersions": "< 4.10.0",
+      "description": "plexus-archiver 4.10+ requires a newer commons-io (BoundedInputStream.builder()) than the one bundled with maven-war-plugin 3.4.0 (pinned by uportal-portlet-parent). Revisit once the parent bumps maven-war-plugin to 3.5.x+."
+    },
+    {
+      "matchPackageNames": [
+        "org.mockito:mockito-core",
+        "org.mockito:mockito-inline",
+        "org.mockito:mockito-junit-jupiter"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Mockito 5 uses the inline MockMaker by default; its bundled byte-buddy references ClassFileVersion.JAVA_V21, missing on the byte-buddy pulled transitively via Hibernate/Javassist. Stay on Mockito 4.x until byte-buddy can be reconciled at the parent level."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add jaxb/plexus-archiver/mockito pins + switch Spring/Hibernate to matchPackagePrefixes. Blocks #98 (plexus-archiver 4.11) and future jaxb v4 / mockito v5 proposals.

Same pattern we've applied across the fleet (Bookmarks #136, SimpleContent #522, Webproxy #264): consolidate hand-maintained `matchPackageNames` lists to `matchPackagePrefixes`, add jaxb (`com.sun.xml.bind:jaxb-impl`, `jakarta.xml.bind:jakarta.xml.bind-api`, `org.glassfish.jaxb:jaxb-runtime`) < 3.0 to preserve the `javax.xml.bind.*` namespace, add `plexus-archiver` < 4.10.0 because 4.10+ breaks the current maven-war-plugin 3.4.0 bundled commons-io, add `mockito-core`/`inline`/`junit-jupiter` < 5.0 due to the byte-buddy classpath clash with Hibernate/Javassist.

**Dependabot PRs** are not affected by `renovate.json` — any spring 5.2/6.x, hibernate 5.x, etc. from Dependabot need manual closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)