### PR TITLE
fix: drop dead commons-httpclient 3.1 pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,24 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-            <type>jar</type>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>


### PR DESCRIPTION
Closes Dependabot CVE-2012-5783 (commons-httpclient SSL hostname verification).

FeedbackPortlet declares `commons-httpclient:commons-httpclient:3.1` in `pom.xml` but has zero `org.apache.commons.httpclient.*` imports anywhere in source — verified via `grep -rl 'org.apache.commons.httpclient' src` returns nothing. The dep is dead weight from a long-removed code path.

## Changes

`pom.xml`: remove the `<dependency>commons-httpclient:commons-httpclient:3.1</>` block (and its now-redundant junit/commons-logging `<exclusions>`).

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix