### PR TITLE
chore: bump parent v50 → v51 and drop unused commons-lang dep

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,47 +18,58 @@ under the License.
 This project includes:
   AntLR under BSD License
   AOP alliance under Public Domain
+  Apache Commons Codec under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache POI under The Apache Software License, Version 2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
+  Apache Commons Math under Apache License, Version 2.0
+  Apache POI under Apache License, Version 2.0
   asm under Apache License, Version 2.0
   asm-attrs under Apache License, Version 2.0
   cglib under Apache License, Version 2.0
-  Codec under Apache License, Version 2.0
-  Commons IO under The Apache Software License, Version 2.0
+  Checker Qual under The MIT License
   Commons Lang under The Apache Software License, Version 2.0
+  commons-collections under Apache License, Version 2.0
   dom4j under BSD License
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
+  error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Feedback Portlet under Apache License Version 2.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  FindBugs-jsr305 under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
   Hibernate under GNU LESSER GENERAL PUBLIC LICENSE
   HSQLDB under HSQLDB License
-  HttpClient under Apache License
+  J2ObjC Annotations under Apache License, Version 2.0
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
   Java Transaction API under Commons Development and Distribution License, Version 1.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   JavaBeans(TM) Activation Framework under COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
   JavaMail API (compat) under CDDL or GPLv2+CE
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Portlet API under Commons Development and Distribution License, Version 1.0
   Resource Server API under Apache License Version 2.0
   Resource Server Content under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
+  SparseBitSet under The Apache Software License, Version 2.0
   Spring AOP under The Apache Software License, Version 2.0
   Spring Beans under The Apache Software License, Version 2.0
   Spring Context under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -106,11 +106,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:51](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-51) and drops the unused `commons-lang:commons-lang` dependency. Closes Dependabot CVE-2025-48924.

## Why

Parent v51 replaces `commons-lang 2.6` (EOL, no upstream fix for [CVE-2025-48924](https://github.com/advisories/GHSA-jcpc-3jpw-vfhw)) with `commons-lang3:3.20.0` and `commons-text:1.15.0` in the dM. FeedbackPortlet declared `commons-lang` in its pom but `grep -rl 'org.apache.commons.lang' src` returns nothing — the dep is dead weight from a long-removed code path. Cleanest fix is to drop the declaration entirely rather than migrate to lang3.

## Changes

`pom.xml`:
- Parent `50` → `51`.
- Remove the unused `<dependency>commons-lang:commons-lang</>` block.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix