### PR TITLE
chore(deps): drop resource-server-content overlay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,12 +157,6 @@
 
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <version>${resource-server.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
             <version>${resource-server.version}</version>
             <exclusions>
@@ -391,16 +385,6 @@
                 </dependencies>
                 <configuration>
                     <warName>FeedbackPortlet</warName>
-                    <overlays>
-                        <overlay>
-                            <groupId>org.jasig.resourceserver</groupId>
-                            <artifactId>resource-server-content</artifactId>
-                            <includes>
-                                <include>rs/mdl/1.3.0/css/material.min.css</include>
-                                <include>rs/mdl/1.3.0/js/material.min.js</include>
-                            </includes>
-                        </overlay>
-                    </overlays>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary

Drops the `resource-server-content` WAR overlay from `FeedbackPortlet`. The overlay was unpacking lodash 4.17.4 (4 CVEs), underscore, backbone, modernizr, normalize, and jquery-plugins into the WAR for nothing — none of which any source file references — plus an explicit maven-war-plugin extract of two MDL files (`material.min.css`, `material.min.js`).

## Why this is safe

- The two JSPs that consume MDL (`feedbackSuccess.jsp`, `submitFeedback.jsp`) reference it via `<rs:resourceURL value="/rs/mdl/1.3.0/..."/>`. The `rs:*` taglib does cross-context lookup against whatever webapp is registered as the resource-server context — in uPortal-start that's `/resource-server` (still serving `resource-server-content`'s legacy `rs/` tree). The local WAR's overlay-extracted copy was a fallback that the taglib's cross-context resolution never emitted.
- `grep -rEn '/FeedbackPortlet/rs/' src/` returns no matches.

## Test plan

- [ ] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [ ] WAR has no `rs/` directory (verified)
- [ ] Smoke: `/p/feedback-portlet/?pCm=view` renders submit form, MDL styling intact (loaded via uPortal-start's `/resource-server/rs/mdl/...`)

## Future cleanup

When uPortal-start drops `resource-server-content` (the broader fleet effort), the JSP MDL references need a swap to the modern resource path or an MDL replacement. Not in this PR's scope.