### PR TITLE
chore(release): force tag fetch in release-portlet.sh preflight

### DIFF
--- a/release-portlet.sh
+++ b/release-portlet.sh
@@ -84,7 +84,9 @@ CURRENT=$(git rev-parse --abbrev-ref HEAD)
 [[ "$CURRENT" == "$BRANCH" ]] || fail "on '$CURRENT', expected '$BRANCH'"
 ok "on branch $BRANCH"
 
-git fetch upstream "$BRANCH" --tags --quiet
+# --force so a stale local tag (e.g. one re-cut on upstream during an earlier
+# release) can't fail the fetch and silently abort the script under `set -e`.
+git fetch upstream "$BRANCH" --tags --force --quiet
 LOCAL_HEAD=$(git rev-parse HEAD)
 UPSTREAM_HEAD=$(git rev-parse "upstream/$BRANCH")
 if [[ "$LOCAL_HEAD" != "$UPSTREAM_HEAD" ]]; then


### PR DESCRIPTION
Problem: the tree-state `git fetch upstream <branch> --tags` had **no `--force`**, so a stale local tag (one re-cut on upstream during an earlier release) could exit non-zero and — under `set -euo pipefail` — **silently abort** the whole script right after the branch check. (This bit the uPortal release; the portlet scripts share the same line.)

Goal: don't let stale local tags abort a release.

Changes (`release-portlet.sh`):
- add `--force` to the tree-state tag fetch.

Notes: mirrors uPortal **#3005** (`release-uportal.sh`). This Maven script does **not** need #3005's push-branch fix — `maven-release-plugin` already pushes master to upstream via `scm.developerConnection`. `bash -n` clean.
